### PR TITLE
chore(renovate): enable rebase on conflict

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
 	"extends": ["config:base"],
 	"schedule": ["before 6am every weekday"],
 	"prConcurrentLimit": 5,
+	"rebaseWhen": "conflicted",
 	"packageRules": [
 		{
 			"updateTypes": ["minor", "patch", "pin", "digest"],


### PR DESCRIPTION
Added the "rebaseWhen" option set to "conflicted" in the renovate.json configuration to improve handling of dependency updates during merge conflicts.