### PR TITLE
chore: edit CSP configuration

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -4,7 +4,11 @@
 </script>
 
 <svelte:head>
-	<script defer src="/stats/script.js" data-website-id={PUBLIC_UMAMI_WEBSITE_ID}></script>
+	<script
+		defer
+		src="https://cloud.umami.is/script.js"
+		data-website-id={PUBLIC_UMAMI_WEBSITE_ID}
+	></script>
 </svelte:head>
 
 <div>

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -12,17 +12,6 @@ const config = {
 		// If your environment is not supported, or you settled on a specific environment, switch out the adapter.
 		// See https://kit.svelte.dev/docs/adapters for more information about adapters.
 		adapter: adapter(),
-		csp: {
-			mode: 'auto',
-			directives: {
-				'default-src': ['self'],
-				'script-src': ['self', 'unsafe-eval', 'unsafe-inline'],
-				'img-src': ['self', 'data:'],
-				'object-src': ['none'],
-				'base-uri': ['none'],
-				'style-src': ['self', 'unsafe-inline']
-			}
-		},
 		alias: {
 			$components: './src/components',
 			$routes: './src/routes',

--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,0 @@
-{
-	"rewrites": [
-		{
-			"source": "/stats/:match*",
-			"destination": "https://cloud.umami.is/:match*"
-		}
-	]
-}


### PR DESCRIPTION
fixes an issue where the browser throwed an console error because of
>Fetch API cannot load https://api-gateway.umami.dev/api/send. Refused to connect because it violates the document's Content Security Policy.